### PR TITLE
Ensure GitHub Pages loads Ukrainian homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ The project provides a snapshot of the LEM Station web presence in both Ukrainia
 ## Deployment
 
 1. Upload the repository contents to your web server.
-2. Rename `htaccess` to `.htaccess` so that Apache style rewrite rules and the custom index take effect.
-3. Ensure your server uses `page8455448.html` as the start page (as defined in `.htaccess`).
+2. If you are using Apache, rename `htaccess` to `.htaccess` so that the rewrite rules and custom start page work.
+3. When serving from GitHub Pages, `.htaccess` is ignored. In this repository an `index.html` file redirects to `page8455448.html` so that `https://leodrom.github.io/LEMStation` opens the correct home page.
+4. Ensure your server uses `page8455448.html` as the start page (either via `.htaccess` or the redirect).
 
 ## Editing
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=page8455448.html">
+  <script>window.location.href = 'page8455448.html';</script>
+  <title>LEM Station</title>
+</head>
+<body>
+  <p>If you are not redirected automatically, follow <a href="page8455448.html">this link</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` that redirects to `page8455448.html`
- document GitHub Pages setup in the README

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6856a4ceb2a4832a82e27d6d36d3152a